### PR TITLE
feat: Optional keepalive for the http connection

### DIFF
--- a/oscfs/obs.py
+++ b/oscfs/obs.py
@@ -199,6 +199,17 @@ class Obs:
         return f.read()
 
     @transparent_retry()
+    def about(self):
+        url = osc.core.makeurl(
+            self.m_apiurl,
+            ['about']
+        )
+
+        f = osc.core.http_GET(url)
+
+        return f.read()
+
+    @transparent_retry()
     def _getPackageRevisions(self, project, package, fmt):
         """Returns the list of revisions for the given project/package
         path in the given fmt. @fmt can be any of ('text, 'csv',


### PR DESCRIPTION
Long running connections and strict firewall policies (one can argue that are not RFC compliant but that's besides the point) can incur in connections getting stalled forever.

Upon connecting to the OBS backend, every so minutes (5 min) to "keep the line up" when using a connection pool to interact with the OBS Backend.